### PR TITLE
B UI lda 19 add a now what readme file to the root of any project generated with a prefab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ node_modules
 npm-debug.log
 ./components
 log.txt
-.builda.json
-.buildcomrc
 .nyc_output/
 coverage/
 ./src/helpers/globals.ts

--- a/dist/scripts/execute.js
+++ b/dist/scripts/execute.js
@@ -18,7 +18,8 @@ const execute = async (config, command) => {
         const { app_root, package_manager } = config;
         const buildDir = node_path_1.default.join(app_root, globals_1.default.buildaDir, 'build');
         const packageJson = require(node_path_1.default.resolve(buildDir, 'package.json'));
-        const script = packageJson.scripts[command];
+        const scripts = packageJson.scripts;
+        const script = scripts[command];
         if (!script) {
             (0, _helpers_1.throwError)(`No script found with the name '${command}'`);
         }

--- a/dist/scripts/prefab-init.js
+++ b/dist/scripts/prefab-init.js
@@ -179,6 +179,15 @@ const prefabInit = async ({ presetAnswers, appName, outputDirectory, pathName, p
             if (node_fs_1.default.existsSync(buildaConfigPath)) {
                 node_fs_1.default.copyFileSync(buildaConfigPath, node_path_1.default.join(rootBuildaPath, 'config.json'));
             }
+            // Create a new package.json file in the root directory with updated scripts
+            const packageJson = require(node_path_1.default.resolve(workingDir, 'package.json'));
+            const scripts = packageJson.scripts;
+            const buildaScripts = {};
+            Object.entries(scripts).map(([key]) => {
+                buildaScripts[key] = `builda -x ${key}`;
+            });
+            const newPackageJson = Object.assign(Object.assign({}, packageJson), { scripts: buildaScripts });
+            node_fs_1.default.writeFileSync(node_path_1.default.join(rootDir, 'package.json'), JSON.stringify(newPackageJson, null, 2));
             // Delete the .builda directory from the build directory
             if (node_fs_1.default.existsSync(buildaPath)) {
                 node_fs_1.default.rmSync(buildaPath, { recursive: true });

--- a/dist/scripts/prefab-init.js
+++ b/dist/scripts/prefab-init.js
@@ -235,7 +235,7 @@ const prefabInit = async ({ presetAnswers, appName, outputDirectory, pathName, p
                     (0, _helpers_1.printMessage)(`Running ${packageManagerType} install`, 'processing');
                     try {
                         const childProcess = (0, execa_1.default)(packageManagerType, ['install'], {
-                            cwd: workingDir,
+                            cwd: rootDir,
                             all: true
                         });
                         (_a = childProcess === null || childProcess === void 0 ? void 0 : childProcess.all) === null || _a === void 0 ? void 0 : _a.pipe(process.stdout);
@@ -243,7 +243,8 @@ const prefabInit = async ({ presetAnswers, appName, outputDirectory, pathName, p
                         (0, _helpers_1.printMessage)('All dependencies installed.', 'success');
                     }
                     catch (error) {
-                        (0, _helpers_1.printMessage)('Failed to run. Please try running manually.', 'error');
+                        (0, _helpers_1.printMessage)(`Failed to run. Please try running '${packageManagerType} install' manually.`, 'error');
+                        //TODO : Add this documentation
                         return (0, _helpers_1.printMessage)(`For more information about how to use your application, visit: ${websiteUrl}/docs/getting-started`, 'primary');
                     }
                 }
@@ -252,7 +253,7 @@ const prefabInit = async ({ presetAnswers, appName, outputDirectory, pathName, p
                 }
             }
             else {
-                (0, _helpers_1.printMessage)(`Dependencies have not been installed. To install dependencies, run: ${packageManagerType} install`, 'notice');
+                (0, _helpers_1.printMessage)(`Dependencies have not been installed. To install dependencies, run: '${packageManagerType} install'`, 'notice');
             }
             (0, _helpers_1.printMessage)(`Your application, "${name}" has been initialised!`, 'success');
             return (0, _helpers_1.printMessage)(`For more information about how to use your application, visit: ${websiteUrl}/docs/getting-started`, 'primary');

--- a/dist/scripts/watch.js
+++ b/dist/scripts/watch.js
@@ -17,7 +17,8 @@ const watch = (config) => {
             (0, _helpers_1.throwError)('No prefab found in config file. Watch cannot be run without a prefab');
         }
         const watcher = chokidar_1.default.watch(config.app_root, {
-            persistent: true
+            persistent: true,
+            ignored: ['node_modules', '.builda', '.git', '.DS_Store']
         });
         watcher.on('ready', () => {
             (0, _helpers_1.printMessage)('Watching for changes...', 'primary');

--- a/dist/scripts/watch.js
+++ b/dist/scripts/watch.js
@@ -9,6 +9,18 @@ exports.watch = void 0;
 const chokidar_1 = __importDefault(require("chokidar"));
 const _helpers_1 = require("../helpers/index.js");
 const globals_1 = __importDefault(require("../data/globals"));
+const ignored = [
+    'node_modules',
+    '.builda',
+    '.git',
+    '.DS_Store',
+    '.github',
+    '.vscode',
+    'builda',
+    'npm-debug.log',
+    'yarn-error.log',
+    'yarn-debug.log'
+];
 const watch = (config) => {
     if (config) {
         const { prefab, app_root } = config;
@@ -18,7 +30,7 @@ const watch = (config) => {
         }
         const watcher = chokidar_1.default.watch(config.app_root, {
             persistent: true,
-            ignored: ['node_modules', '.builda', '.git', '.DS_Store']
+            ignored
         });
         watcher.on('ready', () => {
             (0, _helpers_1.printMessage)('Watching for changes...', 'primary');

--- a/src/scripts/execute.ts
+++ b/src/scripts/execute.ts
@@ -17,7 +17,8 @@ export const execute = async (config: ConfigFile, command: string) => {
 
     const buildDir = path.join(app_root, globals.buildaDir, 'build');
     const packageJson = require(path.resolve(buildDir, 'package.json'));
-    const script = packageJson.scripts[command];
+    const scripts = packageJson.scripts;
+    const script = scripts[command];
 
     if (!script) {
       throwError(`No script found with the name '${command}'`);

--- a/src/scripts/prefab-init.ts
+++ b/src/scripts/prefab-init.ts
@@ -340,7 +340,7 @@ export const prefabInit = async ({
           printMessage(`Running ${packageManagerType} install`, 'processing');
           try {
             const childProcess = execa(packageManagerType, ['install'], {
-              cwd: workingDir,
+              cwd: rootDir,
               all: true
             });
             childProcess?.all?.pipe(process.stdout);
@@ -348,9 +348,10 @@ export const prefabInit = async ({
             printMessage('All dependencies installed.', 'success');
           } catch (error) {
             printMessage(
-              'Failed to run. Please try running manually.',
+              `Failed to run. Please try running '${packageManagerType} install' manually.`,
               'error'
             );
+            //TODO : Add this documentation
             return printMessage(
               `For more information about how to use your application, visit: ${websiteUrl}/docs/getting-started`,
               'primary'
@@ -364,7 +365,7 @@ export const prefabInit = async ({
         }
       } else {
         printMessage(
-          `Dependencies have not been installed. To install dependencies, run: ${packageManagerType} install`,
+          `Dependencies have not been installed. To install dependencies, run: '${packageManagerType} install'`,
           'notice'
         );
       }

--- a/src/scripts/prefab-init.ts
+++ b/src/scripts/prefab-init.ts
@@ -254,6 +254,25 @@ export const prefabInit = async ({
         );
       }
 
+      // Create a new package.json file in the root directory with updated scripts
+      const packageJson = require(path.resolve(workingDir, 'package.json'));
+      const scripts = packageJson.scripts;
+      const buildaScripts = {} as Record<string, string>;
+
+      Object.entries(scripts).map(([key]) => {
+        buildaScripts[key] = `builda -x ${key}`;
+      });
+
+      const newPackageJson = {
+        ...packageJson,
+        scripts: buildaScripts
+      };
+
+      fs.writeFileSync(
+        path.join(rootDir, 'package.json'),
+        JSON.stringify(newPackageJson, null, 2)
+      );
+
       // Delete the .builda directory from the build directory
       if (fs.existsSync(buildaPath)) {
         fs.rmSync(buildaPath, { recursive: true });

--- a/src/scripts/watch.ts
+++ b/src/scripts/watch.ts
@@ -10,6 +10,19 @@ import globals from '@data/globals';
 
 import type { ConfigFile } from '@typedefs/config-file';
 
+const ignored = [
+  'node_modules',
+  '.builda',
+  '.git',
+  '.DS_Store',
+  '.github',
+  '.vscode',
+  'builda',
+  'npm-debug.log',
+  'yarn-error.log',
+  'yarn-debug.log'
+];
+
 export const watch = (config: ConfigFile) => {
   if (config) {
     const { prefab, app_root } = config;
@@ -23,7 +36,7 @@ export const watch = (config: ConfigFile) => {
 
     const watcher = chokidar.watch(config.app_root, {
       persistent: true,
-      ignored: ['node_modules', '.builda', '.git', '.DS_Store']
+      ignored
     });
 
     watcher.on('ready', () => {

--- a/src/scripts/watch.ts
+++ b/src/scripts/watch.ts
@@ -22,7 +22,8 @@ export const watch = (config: ConfigFile) => {
     }
 
     const watcher = chokidar.watch(config.app_root, {
-      persistent: true
+      persistent: true,
+      ignored: ['node_modules', '.builda', '.git', '.DS_Store']
     });
 
     watcher.on('ready', () => {


### PR DESCRIPTION
## 🧰 Issue

Closes https://spacenectar.atlassian.net/browse/BUILDA-20

## 🚀 Overview

Adds a function to allow for using `yarn` commands in the project root, rather than having to call `builda -x` all the time and also allows for `yarn add`, `yarn remove`, `yarn install` etc... to run from project root.

## 🤔 Reason

Relying on users to start using a new `builda` command when they have used `yarn` and `npm` for years isn't really good enough. Plus it was essential that packages could be installed, updated and removed from the project root.

## 📝 Developer Notes

There is possibly a bug with `npm`. This issue is tracked here: https://spacenectar.atlassian.net/browse/BUILDA-22

## 🔨Work carried out

- Updates prefab init script to make a copy of the `package.json` file in the root folder but replaces all of the `scripts` commands with `builda -x` equivalents.
- updates the watch function to ignore certain files
- Updates the init script to install the dependencies in the project root, rather than the .builda/build folder.
- Tests pass
